### PR TITLE
Keep only first 5 after shuffling

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -30,6 +30,7 @@
       }
 
       shuffle(team_names);
+      team_names = team_names.slice(0, 5);
       var numProjects = document.getElementById('num_projects');
       numProjects.innerHTML = `${team_names.length}`;
 


### PR DESCRIPTION
I haven't tested this, so I could be off.

Also, awesomer would be to have a parameter or visible field to control this, but even just limiting to 5 might help with load times and mobile browsers. I also suspect most people won't review more than a few at a time, anyway, and if they come back and reshuffle later, they'll likely get some new ones most of the time.